### PR TITLE
Add space settings - PalletSettings for pallet-spaces

### DIFF
--- a/pallets/spaces/src/lib.rs
+++ b/pallets/spaces/src/lib.rs
@@ -83,7 +83,7 @@ pub struct Space<T: Trait> {
     pub permissions: Option<SpacePermissions>,
 }
 
-#[derive(Encode, Decode, Clone, Eq, PartialEq, RuntimeDebug)]
+#[derive(Encode, Decode, Clone, Eq, PartialEq, Default, RuntimeDebug)]
 #[allow(clippy::option_option)]
 pub struct SpaceUpdate {
     pub parent_id: Option<Option<SpaceId>>,
@@ -459,18 +459,6 @@ impl<T: Trait> Space<T> {
 
     pub fn is_unlisted(&self) -> bool {
         !self.is_public()
-    }
-}
-
-impl Default for SpaceUpdate {
-    fn default() -> Self {
-        SpaceUpdate {
-            parent_id: None,
-            handle: None,
-            content: None,
-            hidden: None,
-            permissions: None,
-        }
     }
 }
 


### PR DESCRIPTION
- Initially this will add an ability to disable handles to update or create new one.
- Also adds tests for handles disabling
- Removes redundant code, which is replaced by `derive` macro option.
- There are some errors here that are fixed in #124 